### PR TITLE
fix: remove bottle :unneeded

### DIFF
--- a/coder-cli-nightly.rb
+++ b/coder-cli-nightly.rb
@@ -2,7 +2,6 @@ class CoderCliNightly < Formula
   desc "Command-line tool for the Coder remote development platform, nightly release channel"
   homepage "https://github.com/cdr/coder-cli"
   version "1.24.0"
-  bottle :unneeded
 
   if OS.mac?
     url "https://github.com/cdr/coder-cli/releases/download/v1.24.0/coder-cli-darwin-amd64.zip"

--- a/coder-cli.rb
+++ b/coder-cli.rb
@@ -2,7 +2,6 @@ class CoderCli < Formula
   desc "Command-line tool for the Coder remote development platform"
   homepage "https://github.com/cdr/coder-cli"
   version "1.24.0"
-  bottle :unneeded
 
   if OS.mac?
     url "https://github.com/cdr/coder-cli/releases/download/v1.24.0/coder-cli-darwin-amd64.zip"


### PR DESCRIPTION
This PR fixes a warning issued by Homebrew when users use the coder or coder-nightly CLI.

> Warning: Calling bottle :unneeded is deprecated! There is no replacement.
Please report this issue to the cdr/coder tap (not Homebrew/brew or Homebrew/core):
 > /usr/local/Homebrew/Library/Taps/cdr/homebrew-coder/coder-cli.rb:5