### PR TITLE
chore: switch workflow from ubuntu22 > ubuntu24 to get glibc upgrade

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, macos-15]
+        os: [ubuntu-24.04, macos-15]
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
I noticed the homebrew builds were way out of date so looked at a run log.

https://github.com/coder/homebrew-coder/actions/runs/27723878872/job/82015628376?pr=368#step:6:162

`brew doctor` fails because it needs glibc newer than 2.35 which is what ubuntu 22 has. 

Changed the os to ubuntu 24 (glibc 2.39) and ran a duplicate of the workflow on a test repo and it no longer failed.